### PR TITLE
Fix Korean font in chinese windows

### DIFF
--- a/ko_KR.ini
+++ b/ko_KR.ini
@@ -1,4 +1,4 @@
-[Audio]
+﻿[Audio]
 Audio backend = 오디오 처리자 (재시작 필요)
 Audio hacks = 오디오 핵
 Audio Latency = 오디오 지연 시간
@@ -58,7 +58,7 @@ Refresh Rate = 새로고침 속도
 [DesktopUI]
 # If your language does not show well with the default font, you can use Font to specify a different one.
 # Just add it to your language's ini file and uncomment it (remove the # by Font).
-#Font = 굴림
+Font = 微软雅黑
 About PPSSPP... = PPSSPP 정보(&A)...
 Auto = 자동(&A)
 Backend = 렌더링 처리자(&B) (PPSSPP 재시작)


### PR DESCRIPTION
Before (전에)
![1](https://cloud.githubusercontent.com/assets/2177532/6203220/216fee76-b550-11e4-9551-598c44b15ea2.jpg)

After (후)
![2](https://cloud.githubusercontent.com/assets/2177532/6203221/25e8a074-b550-11e4-841f-774b463d406c.jpg)


@mgaver @MrGiKILL do you agree this change ?
In Korean(Use google translate): 이 변화를 동의 ?