### PR TITLE
[zh_CN.ini] Fix a line which was too long

### DIFF
--- a/zh_CN.ini
+++ b/zh_CN.ini
@@ -850,7 +850,7 @@ Failed to save state. Error in the file system. = 无法保存即时存档。文
 Fast (lag on slow storage) = 快速 (在慢速存储上会滞后)
 Fast Memory = 快速内存 (不稳定)
 Force real clock sync (slower, less lag) = 强制同步实际时钟频率 (更慢，但是更少延迟)
-frames, 0:off = 每几帧, 0 = 关闭
+frames, 0:off = 每几帧, 0 = 关
 General = 常规设置
 Help the PPSSPP team = 帮助 PPSSPP 团队
 Host (bugs, less lag) = 主机 (有错误, 更少滞后)


### PR DESCRIPTION
A workaround for too long text on Windows 10. "关闭" is more complete, however "关" is also okay.
This issue doesn't happen on Android.
![829](https://user-images.githubusercontent.com/31060534/50556257-9f50f980-0d11-11e9-9a46-fa10b7bab1db.png)
